### PR TITLE
Remove xrho.com

### DIFF
--- a/content/pages/domains.mdoc
+++ b/content/pages/domains.mdoc
@@ -4397,7 +4397,6 @@ The below list is periodically updated; you can also [download it as a CSV](http
 | xoxox.cc                               | disposable    |
 | xperiae5.com                           | disposable    |
 | xrap.de                                | disposable    |
-| xrho.com                               | disposable    |
 | xstyled.net                            | disposable    |
 | xvx.us                                 | disposable    |
 | xww.ro                                 | disposable    |


### PR DESCRIPTION
Not a disposable email domain

```
;; QUESTION SECTION:
;xrho.com.                      IN      MX

;; ANSWER SECTION:
xrho.com.               300     IN      MX      39 route1.mx.cloudflare.net.
xrho.com.               300     IN      MX      72 route3.mx.cloudflare.net.
xrho.com.               300     IN      MX      54 route2.mx.cloudflare.net.
```