### PR TITLE
Remove branding section emphasis highlights from iframe

### DIFF
--- a/content/pages/configuration-and-branding.mdoc
+++ b/content/pages/configuration-and-branding.mdoc
@@ -29,7 +29,7 @@ The "CSS" section lets you customize your newsletter's appearance. To learn more
 
 ## Branding
 
-{% iframe src="https://demo.buttondown.com/settings/general?emphasis=tint_color&emphasis=icon&emphasis=share_image" height=500 /%}
+{% iframe src="https://demo.buttondown.com/settings/general" height=500 /%}
 
 Your newsletter's branding includes its color palette, or "tint color," as well as its logo, or "icon." Your "tint color" appears as an accent in places like hyperlinks or the "Subscribe" button.
 

--- a/content/pages/configuration-and-branding.mdoc
+++ b/content/pages/configuration-and-branding.mdoc
@@ -29,7 +29,7 @@ The "CSS" section lets you customize your newsletter's appearance. To learn more
 
 ## Branding
 
-{% iframe src="https://demo.buttondown.com/settings/general" height=500 /%}
+{% iframe src="https://demo.buttondown.com/settings/general?emphasis=branding" height=500 /%}
 
 Your newsletter's branding includes its color palette, or "tint color," as well as its logo, or "icon." Your "tint color" appears as an accent in places like hyperlinks or the "Subscribe" button.
 


### PR DESCRIPTION
Remove the `emphasis` query parameters from the branding section iframe on the configuration-and-branding page, since the iframe is too small for the accent color, newsletter icon, and share image highlights to all fit.