### PR TITLE
Change "Retrieving comment" to "Retrieving a comment"

### DIFF
--- a/content/pages/api-comments-retrieve.mdoc
+++ b/content/pages/api-comments-retrieve.mdoc
@@ -1,5 +1,5 @@
 ---
-title: Retrieving comment
+title: Retrieving a comment
 endpoint: /comments/{id}
 method: get
 ---


### PR DESCRIPTION
Updates the title of the API comments retrieve docs page to read more naturally.