### PR TITLE
Remove paywall from survey doc demos

### DIFF
--- a/content/pages/surveys.mdoc
+++ b/content/pages/surveys.mdoc
@@ -16,13 +16,13 @@ Want to ask your subscribers a question – and personalize future emails based
 
 All of your newsletter’s surveys live under the [Surveys](https://buttondown.com/surveys) tab. First, tap “+ Add” at top right. You’ll encounter a pop-up that will guide you through the process of creating your survey.
 
-{% iframe src="https://demo.buttondown.com/surveys/new?newsletter=basic-newsletter" width="wide" height=900 /%}
+{% iframe src="https://demo.buttondown.com/surveys/new?newsletter=jenna" width="wide" height=900 /%}
 
 Each survey has room for one question and one question only. If you want to ask multiple questions in a row, you can create an additional survey for each one.
 
 ### Assign a code to your survey
 
-{% iframe src="https://demo.buttondown.com/surveys/new?newsletter=basic-newsletter&emphasis=code" height=500 /%}
+{% iframe src="https://demo.buttondown.com/surveys/new?newsletter=jenna&emphasis=code" height=500 /%}
 
 Then, enter an identifier for your survey in the "Code" field using letters (A–Z) and numbers (0–9). Your subscribers won't see this code, but we recommend making it identifiable so you can retrieve and render your survey more easily.
 
@@ -96,13 +96,13 @@ We put these measures in place to ensure that your survey responses are an accur
 
 Go to the [Surveys](https://buttondown.com/surveys) tab of your newsletter and click on the three dots (`…`) to the far right of your survey’s ID, and then select "Answers" to view a breakdown of your survey’s responses to date:
 
-{% iframe src="https://demo.buttondown.com/surveys/13121cd6-0dfc-424c-bb12-988b0a32fcb3?newsletter=basic-newsletter" height=600 /%}
+{% iframe src="https://demo.buttondown.com/surveys/13121cd6-0dfc-424c-bb12-988b0a32fcb3?newsletter=jenna" height=600 /%}
 
 ### Export your survey's responses
 
 Want to analyze your survey’s responses in more detail? You can export your survey’s data by tapping the check box next to it and then tapping “Export” at the bottom:
 
-{% iframe src="https://demo.buttondown.com/surveys?newsletter=basic-newsletter&emphasis=export" /%}
+{% iframe src="https://demo.buttondown.com/surveys?newsletter=jenna&emphasis=export" /%}
 
 ## Going above and beyond
 


### PR DESCRIPTION
The `basic-newsletter` slug used in the survey docs' demo iframes is on a free plan, so the embedded `/surveys` views render the paywall. Switch to `jenna` (already used for other paid-feature demos like sponsorships) so the embeds show the actual UI.