### PR TITLE
Link external feed list doc to RSS-to-email doc

### DIFF
--- a/content/pages/api-external-feed-list.mdoc
+++ b/content/pages/api-external-feed-list.mdoc
@@ -4,4 +4,4 @@ endpoint: /external_feeds
 method: get
 ---
 
-Use the `/external_feeds` endpoint to list all of your external feeds. External feeds connect an RSS feed to your newsletter to automatically import posts from another site or platform.
+Use the `/external_feeds` endpoint to list all of your external feeds. External feeds connect an RSS feed to your newsletter to automatically import posts from another site or platform. See [RSS-to-email](/rss-to-email) for more information.


### PR DESCRIPTION
Adds a link from the `api-external-feed-list` page to the RSS-to-email doc for additional context on external feeds.