### PR TITLE
Fix dangling preposition on API changelog page

### DIFF
--- a/content/pages/api-changelog-2024-06-21.mdoc
+++ b/content/pages/api-changelog-2024-06-21.mdoc
@@ -3,7 +3,7 @@ title: "2024-06-21"
 navigationTitle: "2024-06-21"
 ---
 
-We've added two new top-level routes for you to query from:
+We've added two new top-level routes that you can query:
 
 - [`/survey_responses`](/api-surveys-list-responses)
 - [`/events`](/api-emails-events)


### PR DESCRIPTION
Rewords "two new top-level routes for you to query from" to "two new top-level routes that you can query" on the 2024-06-21 API changelog page.